### PR TITLE
docs: clarify flat layout installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Market Data Toolkit is a lightweight Python library and command line interface f
 - Optional JSON/YAML watchlist support
 
 ## 📦 Installation
-Use a virtual environment and install in editable mode from the project root (where `pyproject.toml` is located).
+Use a virtual environment and install in editable mode from the project root (where `pyproject.toml` resides). The project uses a flat layout with an explicit `[tool.setuptools.packages.find]` configuration, so the commands below work once you've cloned the repository root.
 
 ### Linux/macOS
 ```bash
@@ -78,6 +78,8 @@ pip install -e .
 pip install -e .[parquet]   # Parquet support
 pip install -e .[yaml]      # YAML watchlists
 ```
+
+**Troubleshooting:** Errors about "Multiple top-level packages discovered" usually mean the repository wasn't cloned correctly or `pyproject.toml` is missing the `[tool.setuptools.packages.find]` section.
 
 ## 🧪 Running Tests
 ```bash


### PR DESCRIPTION
## Summary
- Note that the project uses a flat layout and explicit package configuration, with commands run from the cloned repo root
- Add troubleshooting tip for "Multiple top-level packages" errors when installation fails

## Testing
- `pytest` *(fails: No module named 'marketdata')*
- `pip install -e .` *(fails: Could not find a version that satisfies the requirement setuptools)*

------
https://chatgpt.com/codex/tasks/task_e_68bb095a1c308330882790abf13b779c