### PR TITLE
Add Stooq fallback and watchlist support

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,19 +84,28 @@ print(asof.date(), px)
 ```
 
 ### CLI
+The `prices` command either prints data to the terminal or writes it to disk.
+Tickers may be supplied directly or via a JSON/YAML watchlist file using
+`--config` and `--group`.
 
-Fetch data for multiple tickers directly in the terminal and display the full
-tables on screen:
+**Display on screen**
 
 ```bash
+# compact summary
+prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01
+
+# full table output
 prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --table
 ```
 
-Save prices to CSV files (one per ticker). The folder is created if needed and
-new rows are appended when `--incremental` is used:
+**Write CSV/Parquet**
 
 ```bash
+# create data/ if missing and append new rows when incremental
 prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --out-dir data --incremental
+
+# Parquet instead of CSV
+prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --out-dir data --format parquet
 ```
 
 Multiple tickers may be separated by spaces or commas. On Windows, run the
@@ -151,6 +160,7 @@ Normalized output columns:
 | Adj Close | Adjusted close |
 | Volume | Trading volume |
 | Ticker | Symbol identifier |
+| Source | Data provider (yahoo or stooq) |
 
 ## ⚙️ Error Handling & Logging
 - Retries with exponential backoff before falling back to Stooq

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,11 +11,12 @@ def test_cli_saves_csv(tmp_path, monkeypatch, capsys):
         "Close": [1.0],
         "Adj Close": [1.0],
         "Volume": [0],
+        "Ticker": ["AAPL"],
         "Source": ["yahoo"],
     })
 
     def fake_get_prices(tickers, start, end, on_error="warn"):
-        return {tickers[0]: df}
+        return {tickers[0]: df.assign(Ticker=tickers[0])}
 
     monkeypatch.setattr(prices, "get_prices", fake_get_prices)
     out_dir = tmp_path / "out"
@@ -34,3 +35,39 @@ def test_cli_saves_csv(tmp_path, monkeypatch, capsys):
     assert csv_path.exists()
     saved = pd.read_csv(csv_path)
     assert not saved.empty
+
+
+def test_cli_watchlist(tmp_path, monkeypatch, capsys):
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-05")],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Adj Close": [1.0],
+            "Volume": [0],
+            "Ticker": ["AAPL"],
+            "Source": ["yahoo"],
+        }
+    )
+
+    def fake_get_prices(tickers, start, end, on_error="warn"):
+        return {t: df.assign(Ticker=t) for t in tickers}
+
+    monkeypatch.setattr(prices, "get_prices", fake_get_prices)
+    cfg = tmp_path / "watch.json"
+    cfg.write_text(
+        '{"tickers": ["AAPL"], "groups": {"watchlist": ["AAPL"]}}', encoding="utf-8"
+    )
+    rc = prices.main([
+        "--config",
+        str(cfg),
+        "--start",
+        "2024-01-02",
+        "--end",
+        "2024-01-05",
+    ])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    assert "AAPL" in captured

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -21,6 +21,7 @@ def test_get_latest_close(monkeypatch):
         "Close": [1.0],
         "Adj Close": [1.0],
         "Volume": [0],
+        "Ticker": ["AAPL"],
         "Source": ["yahoo"],
     })
 
@@ -31,3 +32,39 @@ def test_get_latest_close(monkeypatch):
     asof, px = get_latest_close("AAPL")
     assert asof == pd.Timestamp("2024-01-05")
     assert px == 1.0
+
+
+def test_get_prices_schema(monkeypatch):
+    def fake_yf_download(*args, **kwargs):
+        df = pd.DataFrame(
+            {
+                "Open": [1.0],
+                "High": [1.0],
+                "Low": [1.0],
+                "Close": [1.0],
+                "Adj Close": [1.0],
+                "Volume": [0],
+            },
+            index=[pd.Timestamp("2024-01-05")],
+        )
+        df.index.name = "Date"
+        return df
+
+    monkeypatch.setattr("yfinance.download", fake_yf_download)
+    from marketdata import prices as mp
+
+    bars = mp.get_prices(["AAPL"], start="2024-01-01", end="2024-01-06")
+    df = bars["AAPL"]
+    assert list(df.columns) == [
+        "Date",
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Adj Close",
+        "Volume",
+        "Ticker",
+        "Source",
+    ]
+    assert df["Ticker"].iloc[0] == "AAPL"
+    assert df["Source"].iloc[0] == "yahoo"


### PR DESCRIPTION
## Summary
- fix Yahoo FutureWarning by setting `auto_adjust=False`
- add Stooq fallback, ticker column, and schema-enforced CSV output
- allow CLI to load tickers from JSON/YAML watchlists
- document CLI usage and data schema, including new `Source` column

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68bdae19ffc88330bf47d8bbfb5c36a3