### PR TITLE
Harden CSV writing and expand usage docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,11 +62,13 @@ pip install -e .[yaml]      # YAML watchlists
 ```
 
 ## 🧪 Running Tests
-Run the test suite to verify that both the library and CLI are working. The
-tests simulate downloads and write to temporary CSV files.
+Install the test dependency and run the suite to verify that both the library
+and CLI are working. The tests simulate downloads and write to temporary CSV
+files.
 
 ```bash
-pytest
+pip install pytest
+python -m pytest
 ```
 
 ## 🚀 Quick Start
@@ -98,13 +100,19 @@ prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01
 prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --table
 ```
 
+International suffixes and weekend end dates are handled automatically:
+
+```bash
+prices --tickers BP.L OR.PA --start 2024-01-01 --end 2024-06-01
+```
+
 **Write CSV/Parquet**
 
 ```bash
 # create data/ if missing and append new rows when incremental
 prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --out-dir data --incremental
 
-# Parquet instead of CSV
+# Parquet instead of CSV (requires `pip install -e .[parquet]`)
 prices --tickers AAPL MSFT --start 2024-01-01 --end 2024-06-01 --out-dir data --format parquet
 ```
 

--- a/marketdata/prices.py
+++ b/marketdata/prices.py
@@ -128,6 +128,14 @@ def save_prices_csv(bars: Dict[str, pd.DataFrame], out_dir: str, incremental: bo
     for t, df in bars.items():
         if df.empty:
             continue
+
+        if "Date" not in df.columns:
+            if df.index.name == "Date":
+                df = df.reset_index()
+            else:  # pragma: no cover - unexpected schema
+                log.error("%s: missing 'Date' column", t)
+                continue
+
         path = f"{out_dir}/{t.replace('^','_')}_D.csv"
         try:
             if incremental:


### PR DESCRIPTION
## Summary
- Ensure CSV writer gracefully handles frames missing a `Date` column
- Document installing pytest and provide examples for suffix mapping and parquet

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68bdb46792648330a1a238a46cb6757e