### PR TITLE
Handle malformed CSVs when appending prices

### DIFF
--- a/marketdata/prices.py
+++ b/marketdata/prices.py
@@ -141,9 +141,17 @@ def save_prices_csv(bars: Dict[str, pd.DataFrame], out_dir: str, incremental: bo
             if incremental:
                 try:
                     old = pd.read_csv(path, parse_dates=["Date"])
+                    if "Date" not in old.columns and old.index.name == "Date":
+                        old = old.reset_index()
+                except Exception:  # FileNotFoundError or malformed file
+                    old = pd.DataFrame()
+                if not old.empty:
                     df = pd.concat([old, df], ignore_index=True)
-                except FileNotFoundError:
-                    pass
+                if "Date" not in df.columns and df.index.name == "Date":
+                    df = df.reset_index()
+                if "Date" not in df.columns:
+                    log.error("%s: missing 'Date' column", t)
+                    continue
             cols = [
                 "Date",
                 "Open",

--- a/tests/test_prices.py
+++ b/tests/test_prices.py
@@ -68,3 +68,42 @@ def test_get_prices_schema(monkeypatch):
     ]
     assert df["Ticker"].iloc[0] == "AAPL"
     assert df["Source"].iloc[0] == "yahoo"
+
+
+def test_save_prices_csv_bad_existing(tmp_path):
+    from marketdata.prices import save_prices_csv
+
+    # Create a malformed existing CSV file without the expected schema
+    bad = tmp_path / "AAPL_D.csv"
+    bad.write_text("foo,bar\n1,2\n")
+
+    df = pd.DataFrame(
+        {
+            "Date": [pd.Timestamp("2024-01-05")],
+            "Open": [1.0],
+            "High": [1.0],
+            "Low": [1.0],
+            "Close": [1.0],
+            "Adj Close": [1.0],
+            "Volume": [0],
+            "Ticker": ["AAPL"],
+            "Source": ["yahoo"],
+        }
+    )
+
+    paths = save_prices_csv({"AAPL": df}, out_dir=str(tmp_path), incremental=True)
+    assert paths == [str(bad)]
+
+    out = pd.read_csv(paths[0])
+    assert list(out.columns) == [
+        "Date",
+        "Open",
+        "High",
+        "Low",
+        "Close",
+        "Adj Close",
+        "Volume",
+        "Ticker",
+        "Source",
+    ]
+    assert len(out) == 1


### PR DESCRIPTION
## Summary
- make `save_prices_csv` resilient to malformed existing CSV files by validating and repairing the `Date` column
- add regression test ensuring malformed CSVs don't prevent incremental writes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9c2774083309a38f5144c3111c8